### PR TITLE
Fix iOS Safari viewport height handling

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import PageTransition from '@/components/PageTransition'
 import { AnimatedBottomNav, AnimatedNavItem, AnimatedTopNav } from '@/components/AnimatedNavigation'
 import { useTranslation } from 'react-i18next'
 import OnboardingDetector from '@/components/OnboardingDetector'
+import useDynamicViewportHeight from '@/hooks/useDynamicViewportHeight'
 
 const Layout = () => {
   const location = useLocation()
@@ -39,9 +40,14 @@ const Layout = () => {
     },
   ]
 
+  useDynamicViewportHeight()
+
   return (
     <OnboardingDetector>
-      <div className="flex flex-col h-screen bg-gray-50 safe-area-padding">
+      <div
+        className="flex flex-col bg-gray-50 safe-area-padding min-h-screen"
+        style={{ minHeight: 'var(--app-height)' }}
+      >
       {/* 顶部导航栏 */}
       <AnimatedTopNav title="Payments Maps" className="nav-top fixed top-0 left-0 right-0 webkit-overflow-scrolling">
         <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">

--- a/src/hooks/useDynamicViewportHeight.ts
+++ b/src/hooks/useDynamicViewportHeight.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+
+/**
+ * Ensures that the CSS variable `--app-height` always reflects the actual viewport
+ * height on iOS Safari and other mobile browsers where the `100vh` unit can be
+ * inaccurate because of dynamic toolbars.
+ */
+const useDynamicViewportHeight = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return
+    }
+
+    const setAppHeight = () => {
+      const viewport = window.visualViewport
+      const height = viewport ? viewport.height : window.innerHeight
+      document.documentElement.style.setProperty('--app-height', `${height}px`)
+    }
+
+    setAppHeight()
+
+    window.addEventListener('resize', setAppHeight)
+    window.addEventListener('orientationchange', setAppHeight)
+
+    const viewport = window.visualViewport
+    viewport?.addEventListener('resize', setAppHeight)
+    viewport?.addEventListener('scroll', setAppHeight)
+
+    return () => {
+      window.removeEventListener('resize', setAppHeight)
+      window.removeEventListener('orientationchange', setAppHeight)
+      viewport?.removeEventListener('resize', setAppHeight)
+      viewport?.removeEventListener('scroll', setAppHeight)
+    }
+  }, [])
+}
+
+export default useDynamicViewportHeight

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,7 @@ html, body, #root {
 }
 
 :root {
+  --app-height: 100vh;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   line-height: 1.5;
   font-weight: 400;


### PR DESCRIPTION
## Summary
- add a dynamic viewport height hook that keeps a CSS custom property in sync with the real mobile viewport size
- update the application layout to use the dynamic viewport height variable so the shell fills the screen on iOS Safari
- provide a default value for the viewport height CSS variable as a fallback for non-mobile environments

## Testing
- pnpm lint *(fails: existing lint errors across mcp-client, mcp-server, and various src files)*

------
https://chatgpt.com/codex/tasks/task_e_68eb1f3ba9d083238028719b25e78bc6