### PR TITLE
Fix map cleanup when leaving page

### DIFF
--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -159,8 +159,12 @@ const Map = () => {
     return () => {
       mounted = false
       clearTimeout(timeoutId)
-      if (mapInstance) {
-        mapInstance.destroy()
+
+      const currentMapInstance = useMapStore.getState().mapInstance
+      if (currentMapInstance) {
+        if (typeof currentMapInstance.destroy === 'function') {
+          currentMapInstance.destroy()
+        }
         setMapInstance(null)
       }
     }
@@ -178,7 +182,9 @@ const Map = () => {
     if (!mapInstance || !window.AMap) return
 
     // 清除现有标记
-    mapInstance.clearMap()
+    if (typeof mapInstance.clearMap === 'function') {
+      mapInstance.clearMap()
+    }
     
     // 添加POS机标记
     posMachines.forEach((pos) => {

--- a/src/stores/useMapStore.ts
+++ b/src/stores/useMapStore.ts
@@ -80,7 +80,7 @@ interface MapState {
   viewMode: 'map' | 'list'
   
   // Actions
-  setMapInstance: (map: AMap.Map) => void
+  setMapInstance: (map: AMap.Map | null) => void
   getCurrentLocation: () => Promise<void>
   loadPOSMachines: (bounds?: { northeast: [number, number]; southwest: [number, number] }) => Promise<void>
   selectPOSMachine: (posMachine: POSMachine | null) => void


### PR DESCRIPTION
## Summary
- clear stale AMap instances when navigating away from the map
- guard map marker cleanup to avoid calling clearMap on an invalid instance

## Testing
- pnpm check *(fails: missing GoogleTest, DebugRole, SupabaseTest modules)*

------
https://chatgpt.com/codex/tasks/task_e_68eb2002b08c8323bd8b732c38f24d40