### PR TITLE
Improve layout stability for app navigation

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Outlet, useLocation, Link } from 'react-router-dom'
 import { Map, List, User, Plus, Building2, HelpCircle } from 'lucide-react'
 import { useAuthStore } from '@/stores/useAuthStore'
@@ -42,6 +43,37 @@ const Layout = () => {
 
   useDynamicViewportHeight()
 
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return
+    }
+
+    const updateLayoutOffsets = () => {
+      const topNav = document.querySelector<HTMLElement>('.nav-top')
+      const bottomNav = document.querySelector<HTMLElement>('.nav-bottom')
+
+      const topHeight = topNav?.offsetHeight ?? 0
+      const bottomHeight = bottomNav?.offsetHeight ?? 0
+
+      document.documentElement.style.setProperty('--layout-top-offset', `${topHeight}px`)
+      document.documentElement.style.setProperty('--layout-bottom-offset', `${bottomHeight}px`)
+    }
+
+    updateLayoutOffsets()
+
+    window.addEventListener('resize', updateLayoutOffsets)
+    window.addEventListener('orientationchange', updateLayoutOffsets)
+    window.visualViewport?.addEventListener('resize', updateLayoutOffsets)
+    window.visualViewport?.addEventListener('scroll', updateLayoutOffsets)
+
+    return () => {
+      window.removeEventListener('resize', updateLayoutOffsets)
+      window.removeEventListener('orientationchange', updateLayoutOffsets)
+      window.visualViewport?.removeEventListener('resize', updateLayoutOffsets)
+      window.visualViewport?.removeEventListener('scroll', updateLayoutOffsets)
+    }
+  }, [])
+
   return (
     <OnboardingDetector>
       <div
@@ -79,11 +111,13 @@ const Layout = () => {
 
         {/* 主内容区域 */}
         <main
-          className="flex-1 overflow-x-hidden overflow-y-auto pt-16 pb-16"
+          className="flex-1 overflow-x-hidden overflow-y-auto"
           style={{
-            paddingTop: 'calc(4rem + env(safe-area-inset-top))',
-            paddingBottom: 'calc(4rem + env(safe-area-inset-bottom))',
+            paddingTop: 'var(--layout-top-offset, calc(4rem + env(safe-area-inset-top)))',
+            paddingBottom: 'var(--layout-bottom-offset, calc(4rem + env(safe-area-inset-bottom)))',
+            minHeight: 'calc(var(--app-height, 100vh) - var(--layout-top-offset, 4rem) - var(--layout-bottom-offset, 4rem))',
             WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
           }}
         >
           <PageTransition variant="fadeIn">

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,8 @@ html, body, #root {
 
 :root {
   --app-height: 100vh;
+  --layout-top-offset: 4rem;
+  --layout-bottom-offset: 4rem;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   line-height: 1.5;
   font-weight: 400;
@@ -31,6 +33,10 @@ html, body, #root {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  overscroll-behavior-y: none;
 }
 
 /* Safari 特有的样式修复 */


### PR DESCRIPTION
## Summary
- dynamically calculate top and bottom navigation offsets so page content always fits the viewport without shifting the menus
- define default layout offset CSS variables and suppress browser overscroll to keep interactions smooth on mobile

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68eb310d719883238feccf6262e942a0