### PR TITLE
Add international language gate and localized onboarding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/stores/useAuthStore'
 import { useVersionCheck } from '@/hooks/useVersionCheck'
 import VersionUpdateModal from '@/components/VersionUpdateModal'
 import { supabase, type User } from '@/lib/supabase'
+import InitialExperiencePrompt from '@/components/InitialExperiencePrompt'
 
 function App() {
   const { initialize, setUser } = useAuthStore()
@@ -52,6 +53,7 @@ function App() {
 
   return (
     <>
+      <InitialExperiencePrompt />
       <RouterProvider router={router} />
       <Toaster 
         position="top-center"

--- a/src/components/InitialExperiencePrompt.tsx
+++ b/src/components/InitialExperiencePrompt.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Globe2, ShieldCheck, Sparkles } from 'lucide-react'
+import { useLocaleStore } from '@/stores/useLocaleStore'
+
+interface ExperienceOption {
+  key: 'domestic' | 'international'
+  language: string
+}
+
+const experienceOptions: ExperienceOption[] = [
+  { key: 'domestic', language: 'zh' },
+  { key: 'international', language: 'en' },
+]
+
+const InitialExperiencePrompt = () => {
+  const { t } = useTranslation()
+  const {
+    hasSelectedLanguage,
+    setPreference,
+    language,
+    experience,
+  } = useLocaleStore()
+  const [shouldRender, setShouldRender] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    setShouldRender(true)
+  }, [])
+
+  const activeKey = useMemo(() => experience, [experience])
+
+  if (!shouldRender || hasSelectedLanguage || dismissed) {
+    return null
+  }
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 z-[10000] flex flex-col"
+      >
+        <div
+          className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"
+          aria-hidden="true"
+        />
+        <motion.div
+          initial={{ y: -40, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          transition={{ type: 'spring', stiffness: 120, damping: 18 }}
+          className="relative mx-auto mt-6 w-[min(96vw,720px)] rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-2xl backdrop-blur"
+        >
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-widest text-blue-500">
+                  {t('experiencePrompt.badge')}
+                </p>
+                <h2 className="mt-1 text-2xl font-bold text-slate-900">
+                  {t('experiencePrompt.title')}
+                </h2>
+                <p className="mt-2 text-sm text-slate-600">
+                  {t('experiencePrompt.subtitle')}
+                </p>
+              </div>
+              <div className="hidden sm:flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 text-blue-600">
+                <Globe2 className="h-8 w-8" />
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              {experienceOptions.map((option) => {
+                const isActive = activeKey === option.key && language === option.language
+                const label = t(`experiencePrompt.options.${option.key}.title`)
+                const description = t(`experiencePrompt.options.${option.key}.description`)
+
+                return (
+                  <motion.button
+                    key={option.key}
+                    type="button"
+                    whileHover={{ scale: 1.01 }}
+                    whileTap={{ scale: 0.98 }}
+                    className={`group flex h-full flex-col gap-3 rounded-2xl border p-4 text-left transition-all duration-200 ${
+                      isActive
+                        ? 'border-blue-500 bg-gradient-to-br from-blue-50 via-white to-indigo-50 shadow-lg'
+                        : 'border-slate-200 bg-white hover:border-blue-200 hover:shadow-md'
+                    }`}
+                    onClick={() => {
+                      setPreference(option.language, option.key)
+                      setDismissed(true)
+                    }}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div
+                        className={`flex h-11 w-11 items-center justify-center rounded-xl border text-lg font-semibold ${
+                          isActive
+                            ? 'border-blue-500 bg-blue-100 text-blue-700'
+                            : 'border-slate-200 bg-slate-100 text-slate-700'
+                        }`}
+                      >
+                        {t(`experiencePrompt.options.${option.key}.short`)}
+                      </div>
+                      <div>
+                        <p className="text-base font-semibold text-slate-900">
+                          {label}
+                        </p>
+                        <p className="text-xs text-slate-500">
+                          {t(`experiencePrompt.options.${option.key}.hint`)}
+                        </p>
+                      </div>
+                    </div>
+                    <p className="flex-1 text-sm text-slate-600">
+                      {description}
+                    </p>
+                    <div className="flex items-center gap-2 text-sm font-medium text-blue-600">
+                      <Sparkles className="h-4 w-4" />
+                      <span>{t(`experiencePrompt.options.${option.key}.cta`)}</span>
+                    </div>
+                  </motion.button>
+                )
+              })}
+            </div>
+
+            <div className="rounded-2xl border border-slate-100 bg-slate-50/70 p-4">
+              <div className="flex items-start gap-3">
+                <div className="mt-1 rounded-full bg-blue-100 p-2 text-blue-600">
+                  <ShieldCheck className="h-4 w-4" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-semibold text-slate-800">
+                    {t('experiencePrompt.promo.title')}
+                  </p>
+                  <ul className="mt-2 space-y-1 text-xs text-slate-600">
+                    {t('experiencePrompt.promo.points', { returnObjects: true })
+                      .map((item: string, index: number) => (
+                        <li key={index}>• {item}</li>
+                      ))}
+                  </ul>
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-slate-500">
+                {t('experiencePrompt.footer')}
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  )
+}
+
+export default InitialExperiencePrompt

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Globe } from 'lucide-react'
 import { motion } from 'framer-motion'
-import { changeLanguage, getCurrentLanguage, getLanguageDisplayName } from '@/lib/i18n'
+import { getLanguageDisplayName, supportedLanguages } from '@/lib/i18n'
+import { useLocaleStore } from '@/stores/useLocaleStore'
 
 interface LanguageSwitcherProps {
   className?: string
@@ -14,16 +15,18 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
   showLabel = true 
 }) => {
   const { t } = useTranslation()
-  const currentLanguage = getCurrentLanguage()
-  
+  const { language, setPreference, experience } = useLocaleStore()
+
   const languages = [
+    { code: 'zh', name: '中文', flag: '🇨🇳' },
     { code: 'en', name: 'English', flag: '🇺🇸' },
     { code: 'ru', name: 'Русский', flag: '🇷🇺' },
     { code: 'de', name: 'Deutsch', flag: '🇩🇪' }
   ]
 
   const handleLanguageChange = (languageCode: string) => {
-    changeLanguage(languageCode)
+    const mode = languageCode === 'zh' ? 'domestic' : 'international'
+    setPreference(languageCode, mode)
   }
 
   return (
@@ -37,17 +40,19 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
         )}
         
         <div className="flex gap-1">
-          {languages.map((language) => {
-            const isActive = currentLanguage === language.code
-            
+          {languages
+            .filter((item) => Object.keys(supportedLanguages).includes(item.code))
+            .map((languageOption) => {
+              const isActive = language === languageOption.code
+
             return (
               <motion.button
-                key={language.code}
-                onClick={() => handleLanguageChange(language.code)}
+                key={languageOption.code}
+                onClick={() => handleLanguageChange(languageOption.code)}
                 className={`
                   px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200
-                  ${isActive 
-                    ? 'bg-blue-500 text-white shadow-md' 
+                  ${isActive
+                    ? 'bg-blue-500 text-white shadow-md'
                     : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                   }
                 `}
@@ -60,8 +65,8 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
                 }}
               >
                 <div className="flex items-center gap-1">
-                  <span>{language.flag}</span>
-                  <span>{language.code.toUpperCase()}</span>
+                  <span>{languageOption.flag}</span>
+                  <span>{languageOption.code.toUpperCase()}</span>
                 </div>
               </motion.button>
             )
@@ -71,7 +76,13 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
       
       {/* 当前语言显示 */}
       <div className="mt-2 text-xs text-gray-500">
-        {t('common.currentLanguage')}: {getLanguageDisplayName(currentLanguage)}
+        {t('common.currentLanguage')}: {getLanguageDisplayName(language)}
+      </div>
+
+      <div className="mt-1 text-xs font-medium text-blue-500">
+        {experience === 'domestic'
+          ? t('experience.badge.domestic')
+          : t('experience.badge.international')}
       </div>
     </div>
   )

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,16 +1,22 @@
 import { Outlet, useLocation, Link } from 'react-router-dom'
-import { Map, List, User, Plus, Building2, HelpCircle } from 'lucide-react'
+import { Map, List, User, Plus, Building2, HelpCircle, MapPin, Search, Filter } from 'lucide-react'
 import { useAuthStore } from '@/stores/useAuthStore'
 import PageTransition from '@/components/PageTransition'
 import { AnimatedBottomNav, AnimatedNavItem, AnimatedTopNav } from '@/components/AnimatedNavigation'
 import { useTranslation } from 'react-i18next'
 import OnboardingDetector from '@/components/OnboardingDetector'
 import useDynamicViewportHeight from '@/hooks/useDynamicViewportHeight'
+import { useLocaleStore } from '@/stores/useLocaleStore'
+import { useEffect, useMemo, useState } from 'react'
+import OnboardingTour, { type TourStep } from '@/components/OnboardingTour'
 
 const Layout = () => {
   const location = useLocation()
   const { user } = useAuthStore()
   const { t } = useTranslation()
+  const { experience, hasCompletedTour, hasSelectedLanguage, markTourCompleted } = useLocaleStore()
+  const [isTourOpen, setIsTourOpen] = useState(false)
+  const [tourTriggered, setTourTriggered] = useState(false)
 
   const navItems = [
     {
@@ -42,6 +48,82 @@ const Layout = () => {
 
   useDynamicViewportHeight()
 
+  useEffect(() => {
+    if (tourTriggered || !hasSelectedLanguage || hasCompletedTour) {
+      return
+    }
+
+    if (location.pathname.startsWith('/app')) {
+      setTourTriggered(true)
+      const timer = setTimeout(() => setIsTourOpen(true), 600)
+      return () => clearTimeout(timer)
+    }
+  }, [hasCompletedTour, hasSelectedLanguage, location.pathname, tourTriggered])
+
+  const tourSteps: TourStep[] = useMemo(() => {
+    const isInternational = experience === 'international'
+    const baseText = (key: string) => t(key)
+    const text = (key: string) =>
+      isInternational
+        ? t(`${key}_international`, { defaultValue: baseText(key) })
+        : baseText(key)
+
+    return [
+      {
+        target: '.nav-bottom a[href="/app/map"]',
+        title: text('onboardingTour.steps.map.title'),
+        action: text('onboardingTour.steps.map.action'),
+      icon: MapPin,
+      gesture: 'click',
+      spotlightRadius: 60,
+      },
+      {
+        target: '.search-button',
+        title: text('onboardingTour.steps.search.title'),
+        action: text('onboardingTour.steps.search.action'),
+      icon: Search,
+      gesture: 'click',
+      spotlightRadius: 50,
+      },
+      {
+        target: '.nav-bottom a[href="/app/add-pos"]',
+        title: text('onboardingTour.steps.add.title'),
+        action: text('onboardingTour.steps.add.action'),
+      icon: Plus,
+      gesture: 'click',
+      spotlightRadius: 60,
+      },
+      {
+        target: '.filter-button',
+        title: text('onboardingTour.steps.filter.title'),
+        action: text('onboardingTour.steps.filter.action'),
+      icon: Filter,
+      gesture: 'click',
+      spotlightRadius: 50,
+      },
+      {
+        target: '.nav-bottom a[href="/app/profile"]',
+        title: text('onboardingTour.steps.profile.title'),
+        action: text('onboardingTour.steps.profile.action'),
+      icon: User,
+      gesture: 'click',
+      spotlightRadius: 60,
+      },
+    ]
+  }, [experience, t])
+
+  const tourLabels = useMemo(() => ({
+    previous: t('onboardingTour.labels.previous'),
+    next: t('onboardingTour.labels.next'),
+    skip: t('onboardingTour.labels.skip'),
+    done: t('onboardingTour.labels.done'),
+  }), [t])
+
+  const handleTourComplete = () => {
+    setIsTourOpen(false)
+    markTourCompleted()
+  }
+
   return (
     <OnboardingDetector>
       <div
@@ -57,6 +139,11 @@ const Layout = () => {
             <img src="/web_logo.JPG" alt="Payments Maps Logo" className="w-8 h-8" />
           </Link>
           <div className="flex items-center space-x-2">
+            <span className="hidden sm:inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600">
+              {experience === 'domestic'
+                ? t('experience.badge.domestic')
+                : t('experience.badge.international')}
+            </span>
             <Link
               to="/app/help"
               className="p-2 text-gray-600 hover:text-blue-600 transition-colors"
@@ -110,6 +197,12 @@ const Layout = () => {
             )
           })}
         </AnimatedBottomNav>
+        <OnboardingTour
+          steps={tourSteps}
+          isOpen={isTourOpen && tourSteps.length > 0}
+          onComplete={handleTourComplete}
+          labels={tourLabels}
+        />
       </div>
     </OnboardingDetector>
   )

--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -1,127 +1,98 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { X, ChevronRight, ChevronLeft, MapPin, Search, Plus, Filter, User, Check } from 'lucide-react'
+import { X, ChevronRight, ChevronLeft, Check } from 'lucide-react'
 import { createPortal } from 'react-dom'
 
-interface TourStep {
-  target: string // CSS selector for the target element
+export interface TourStep {
+  target: string
   title: string
   icon?: React.ComponentType<any>
-  action?: string // 动作提示，如 "点击这里" 
+  action?: string
   spotlightRadius?: number
   position?: 'top' | 'bottom' | 'left' | 'right' | 'center'
   offset?: { x: number; y: number }
   gesture?: 'click' | 'swipe' | 'drag' | 'long-press'
 }
 
-const tourSteps: TourStep[] = [
-  {
-    target: '.nav-bottom a[href="/app/map"]',
-    title: '地图浏览',
-    icon: MapPin,
-    action: '点击查看附近POS机',
-    position: 'top',
-    gesture: 'click',
-    spotlightRadius: 60
-  },
-  {
-    target: '.search-button',
-    title: '搜索功能',
-    icon: Search,
-    action: '搜索商户或地址',
-    position: 'bottom',
-    gesture: 'click',
-    spotlightRadius: 50
-  },
-  {
-    target: '.nav-bottom a[href="/app/add-pos"]',
-    title: '添加POS机',
-    icon: Plus,
-    action: '分享你知道的POS机',
-    position: 'top',
-    gesture: 'click',
-    spotlightRadius: 60
-  },
-  {
-    target: '.filter-button',
-    title: '筛选功能',
-    icon: Filter,
-    action: '按支付方式筛选',
-    position: 'bottom',
-    gesture: 'click',
-    spotlightRadius: 50
-  },
-  {
-    target: '.nav-bottom a[href="/app/profile"]',
-    title: '个人中心',
-    icon: User,
-    action: '管理你的收藏和历史',
-    position: 'top',
-    gesture: 'click',
-    spotlightRadius: 60
-  }
-]
-
-interface OnboardingTourProps {
-  onComplete: () => void
-  isOpen: boolean
+interface OnboardingTourLabels {
+  previous: string
+  next: string
+  skip: string
+  done: string
 }
 
-const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
+interface OnboardingTourProps {
+  steps: TourStep[]
+  isOpen: boolean
+  onComplete: () => void
+  labels: OnboardingTourLabels
+}
+
+const OnboardingTour = ({ steps, isOpen, onComplete, labels }: OnboardingTourProps) => {
   const [currentStep, setCurrentStep] = useState(0)
   const [targetRect, setTargetRect] = useState<DOMRect | null>(null)
   const [isVisible, setIsVisible] = useState(false)
 
-  const currentTourStep = tourSteps[currentStep]
+  const totalSteps = steps.length
+  const currentTourStep = steps[currentStep]
 
-  // 获取目标元素位置
+  useEffect(() => {
+    if (!isOpen) {
+      setCurrentStep(0)
+      setIsVisible(false)
+      return
+    }
+
+    if (currentStep >= steps.length) {
+      setCurrentStep(0)
+    }
+  }, [isOpen, steps.length, currentStep])
+
   const updateTargetPosition = useCallback(() => {
     if (!currentTourStep) return
-    
+
     const element = document.querySelector(currentTourStep.target)
     if (element) {
       const rect = element.getBoundingClientRect()
       setTargetRect(rect)
       setIsVisible(true)
     } else {
-      // 如果元素不存在，尝试下一步
       setTimeout(() => {
-        if (currentStep < tourSteps.length - 1) {
-          handleNext()
+        if (currentStep < totalSteps - 1) {
+          setCurrentStep((step) => Math.min(step + 1, totalSteps - 1))
         }
       }, 500)
     }
-  }, [currentStep, currentTourStep])
+  }, [currentTourStep, currentStep, totalSteps])
 
   useEffect(() => {
-    if (isOpen) {
-      // 初始化和窗口调整时更新位置
-      const updatePosition = () => {
-        setTimeout(updateTargetPosition, 100)
-      }
-      
-      updatePosition()
-      
-      // 监听窗口调整和滚动
-      window.addEventListener('resize', updateTargetPosition)
-      window.addEventListener('scroll', updateTargetPosition, true) // 使用捕获阶段监听滚动
-      
-      // 监听方向变化（移动设备）
-      window.addEventListener('orientationchange', updatePosition)
-      
-      return () => {
-        window.removeEventListener('resize', updateTargetPosition)
-        window.removeEventListener('scroll', updateTargetPosition, true)
-        window.removeEventListener('orientationchange', updatePosition)
-      }
+    if (!isOpen) return
+    const timeout = setTimeout(updateTargetPosition, 100)
+    return () => clearTimeout(timeout)
+  }, [isOpen, updateTargetPosition])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleResize = () => updateTargetPosition()
+    const handleScroll = () => updateTargetPosition()
+
+    window.addEventListener('resize', handleResize)
+    window.addEventListener('scroll', handleScroll, true)
+    window.addEventListener('orientationchange', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('scroll', handleScroll, true)
+      window.removeEventListener('orientationchange', handleResize)
     }
-  }, [isOpen, currentStep, updateTargetPosition])
+  }, [isOpen, updateTargetPosition])
 
   const handleNext = () => {
-    if (currentStep < tourSteps.length - 1) {
+    if (currentStep < totalSteps - 1) {
       setIsVisible(false)
       setTimeout(() => {
-        setCurrentStep(currentStep + 1)
+        setCurrentStep((prev) => Math.min(prev + 1, totalSteps - 1))
       }, 200)
     } else {
       handleComplete()
@@ -132,81 +103,63 @@ const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
     if (currentStep > 0) {
       setIsVisible(false)
       setTimeout(() => {
-        setCurrentStep(currentStep - 1)
+        setCurrentStep((prev) => Math.max(prev - 1, 0))
       }, 200)
     }
   }
 
-  const handleComplete = () => {
+  const handleComplete = useCallback(() => {
     setIsVisible(false)
     localStorage.setItem('onboarding_completed', 'true')
     setTimeout(onComplete, 200)
-  }
+  }, [onComplete])
 
-  const handleSkip = () => {
+  const handleSkip = useCallback(() => {
     handleComplete()
-  }
+  }, [handleComplete])
 
-  if (!isOpen || !targetRect || !currentTourStep) return null
+  const tooltipPosition = useMemo(() => {
+    if (!targetRect) return { x: 0, y: 0 }
 
-  // 计算提示框位置，确保不超出屏幕边界
-  const getTooltipPosition = () => {
-    const tooltipWidth = 320 // 提示框预估宽度
-    const tooltipHeight = 280 // 提示框预估高度
+    const tooltipWidth = 320
+    const tooltipHeight = 280
     const margin = 20
-    const screenPadding = 16 // 距离屏幕边缘的最小距离
-    
-    // 获取窗口尺寸
+    const screenPadding = 16
+
     const windowWidth = window.innerWidth
     const windowHeight = window.innerHeight
-    
-    // 目标元素中心点
     const targetCenterX = targetRect.left + targetRect.width / 2
-    const targetCenterY = targetRect.top + targetRect.height / 2
-    
-    // 初始位置（优先在目标下方）
+    const targetBottom = targetRect.bottom + margin
+
     let x = targetCenterX
-    let y = targetRect.bottom + margin
-    
-    // 检查是否超出底部边界
+    let y = targetBottom
+
     if (y + tooltipHeight > windowHeight - screenPadding) {
-      // 尝试放在上方
       y = targetRect.top - tooltipHeight - margin
-      
-      // 如果上方也放不下，则居中显示
+
       if (y < screenPadding) {
         y = Math.max(
           screenPadding,
-          Math.min(
-            windowHeight / 2 - tooltipHeight / 2,
-            windowHeight - tooltipHeight - screenPadding
-          )
+          Math.min(windowHeight / 2 - tooltipHeight / 2, windowHeight - tooltipHeight - screenPadding)
         )
       }
     }
-    
-    // 检查是否超出右边界
+
     if (x + tooltipWidth / 2 > windowWidth - screenPadding) {
       x = windowWidth - tooltipWidth / 2 - screenPadding
     }
-    
-    // 检查是否超出左边界
+
     if (x - tooltipWidth / 2 < screenPadding) {
       x = tooltipWidth / 2 + screenPadding
     }
-    
-    // 确保y值在合理范围内
+
     y = Math.max(screenPadding, Math.min(y, windowHeight - tooltipHeight - screenPadding))
-    
+
     return { x, y }
-  }
+  }, [targetRect])
 
-  const tooltipPosition = getTooltipPosition()
-  const spotlightRadius = currentTourStep.spotlightRadius || 50
-
-  // 手势动画组件
   const GestureIndicator = ({ type }: { type?: string }) => {
-    if (!type) return null
+    if (!type || !targetRect) return null
 
     switch (type) {
       case 'click':
@@ -215,18 +168,14 @@ const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
             className="absolute pointer-events-none"
             style={{
               left: targetRect.left + targetRect.width / 2 - 20,
-              top: targetRect.top + targetRect.height / 2 - 20
+              top: targetRect.top + targetRect.height / 2 - 20,
             }}
             initial={{ scale: 1, opacity: 0 }}
-            animate={{ 
+            animate={{
               scale: [1, 1.5, 1],
-              opacity: [0, 1, 0]
+              opacity: [0, 1, 0],
             }}
-            transition={{
-              duration: 1.5,
-              repeat: Infinity,
-              repeatDelay: 0.5
-            }}
+            transition={{ duration: 1.5, repeat: Infinity, repeatDelay: 0.5 }}
           >
             <div className="w-10 h-10 rounded-full bg-blue-500" />
           </motion.div>
@@ -237,16 +186,10 @@ const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
             className="absolute pointer-events-none"
             style={{
               left: targetRect.left + targetRect.width / 2 - 20,
-              top: targetRect.top + targetRect.height / 2 - 20
+              top: targetRect.top + targetRect.height / 2 - 20,
             }}
-            animate={{
-              x: [0, 50, 0],
-            }}
-            transition={{
-              duration: 1.5,
-              repeat: Infinity,
-              repeatDelay: 0.5
-            }}
+            animate={{ x: [0, 50, 0] }}
+            transition={{ duration: 1.5, repeat: Infinity, repeatDelay: 0.5 }}
           >
             <ChevronRight className="w-10 h-10 text-blue-500" />
           </motion.div>
@@ -256,16 +199,21 @@ const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
     }
   }
 
+  if (!isOpen || !currentTourStep || totalSteps === 0) {
+    return null
+  }
+
+  const spotlightRadius = currentTourStep.spotlightRadius || 50
+
   return createPortal(
     <AnimatePresence>
-      {isVisible && (
+      {isVisible && targetRect && (
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           className="fixed inset-0 z-[9999]"
         >
-          {/* 背景遮罩 with spotlight */}
           <svg className="absolute inset-0 w-full h-full">
             <defs>
               <mask id="spotlight-mask">
@@ -281,45 +229,27 @@ const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
                 />
               </mask>
             </defs>
-            <rect
-              x="0"
-              y="0"
-              width="100%"
-              height="100%"
-              fill="rgba(0, 0, 0, 0.7)"
-              mask="url(#spotlight-mask)"
-            />
+            <rect x="0" y="0" width="100%" height="100%" fill="rgba(0, 0, 0, 0.7)" mask="url(#spotlight-mask)" />
           </svg>
 
-          {/* 高亮边框 */}
           <motion.div
             className="absolute border-2 border-blue-500 rounded-lg pointer-events-none"
             style={{
               left: targetRect.left - 4,
               top: targetRect.top - 4,
               width: targetRect.width + 8,
-              height: targetRect.height + 8
+              height: targetRect.height + 8,
             }}
             initial={{ scale: 0.8, opacity: 0 }}
-            animate={{ 
-              scale: [1, 1.05, 1],
-              opacity: 1
-            }}
+            animate={{ scale: [1, 1.05, 1], opacity: 1 }}
             transition={{
-              scale: {
-                duration: 2,
-                repeat: Infinity
-              },
-              opacity: {
-                duration: 0.3
-              }
+              scale: { duration: 2, repeat: Infinity },
+              opacity: { duration: 0.3 },
             }}
           />
 
-          {/* 手势指示器 */}
           <GestureIndicator type={currentTourStep.gesture} />
 
-          {/* 提示卡片 */}
           <motion.div
             className="absolute bg-white rounded-2xl shadow-2xl p-4 sm:p-6 w-[calc(100vw-32px)] max-w-sm"
             style={{
@@ -327,13 +257,12 @@ const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
               top: tooltipPosition.y,
               transform: 'translate(-50%, 0)',
               maxHeight: 'calc(100vh - 32px)',
-              overflowY: 'auto'
+              overflowY: 'auto',
             }}
             initial={{ scale: 0.8, opacity: 0, y: 20 }}
             animate={{ scale: 1, opacity: 1, y: 0 }}
             transition={{ duration: 0.3, delay: 0.1 }}
           >
-            {/* 关闭按钮 */}
             <button
               onClick={handleSkip}
               className="absolute top-2 right-2 p-1 text-gray-400 hover:text-gray-600 transition-colors z-10"
@@ -341,7 +270,6 @@ const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
               <X className="w-5 h-5" />
             </button>
 
-            {/* 内容 */}
             <div className="flex items-start gap-3 sm:gap-4">
               {currentTourStep.icon && (
                 <div className="flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-xl flex items-center justify-center">
@@ -360,9 +288,8 @@ const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
               </div>
             </div>
 
-            {/* 进度指示器 */}
             <div className="flex items-center justify-center gap-1 mt-3 sm:mt-4 mb-3 sm:mb-4">
-              {tourSteps.map((_, index) => (
+              {steps.map((_, index) => (
                 <motion.div
                   key={index}
                   className={`h-1.5 rounded-full transition-all ${
@@ -378,40 +305,37 @@ const OnboardingTour = ({ onComplete, isOpen }: OnboardingTourProps) => {
               ))}
             </div>
 
-            {/* 导航按钮 */}
             <div className="flex items-center justify-between gap-2">
               <button
                 onClick={handlePrev}
                 disabled={currentStep === 0}
                 className={`flex items-center gap-1 px-2 sm:px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-all ${
-                  currentStep === 0
-                    ? 'text-gray-400 cursor-not-allowed'
-                    : 'text-gray-600 hover:bg-gray-100'
+                  currentStep === 0 ? 'text-gray-400 cursor-not-allowed' : 'text-gray-600 hover:bg-gray-100'
                 }`}
               >
                 <ChevronLeft className="w-3 h-3 sm:w-4 sm:h-4" />
-                <span className="hidden sm:inline">上一步</span>
+                <span className="hidden sm:inline">{labels.previous}</span>
               </button>
 
               <button
                 onClick={handleSkip}
                 className="text-xs sm:text-sm text-gray-500 hover:text-gray-700 transition-colors px-2"
               >
-                跳过
+                {labels.skip}
               </button>
 
               <button
                 onClick={handleNext}
                 className="flex items-center gap-1 px-3 sm:px-4 py-1.5 sm:py-2 bg-gradient-to-r from-blue-500 to-purple-600 text-white rounded-lg text-xs sm:text-sm font-medium hover:shadow-lg transition-all"
               >
-                {currentStep === tourSteps.length - 1 ? (
+                {currentStep === totalSteps - 1 ? (
                   <>
-                    <span className="hidden sm:inline">完成</span>
+                    <span className="hidden sm:inline">{labels.done}</span>
                     <Check className="w-3 h-3 sm:w-4 sm:h-4" />
                   </>
                 ) : (
                   <>
-                    <span className="hidden sm:inline">下一步</span>
+                    <span className="hidden sm:inline">{labels.next}</span>
                     <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4" />
                   </>
                 )}

--- a/src/components/international/InternationalPOSOverview.tsx
+++ b/src/components/international/InternationalPOSOverview.tsx
@@ -1,0 +1,312 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  ArrowLeft,
+  Heart,
+  MapPin,
+  Navigation,
+  CreditCard,
+  Shield,
+  Smartphone,
+  Globe2,
+  Info,
+  Sparkles,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { POSMachine } from '@/lib/supabase'
+import AnimatedButton from '@/components/ui/AnimatedButton'
+import AnimatedCard from '@/components/ui/AnimatedCard'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { AnimatedTopNav } from '@/components/AnimatedNavigation'
+import { useLocaleStore } from '@/stores/useLocaleStore'
+
+export interface InternationalAttemptSummary {
+  result: 'success' | 'failure' | 'unknown'
+  card_name?: string
+  payment_method?: string
+  created_at?: string
+}
+
+interface InternationalPOSOverviewProps {
+  pos: POSMachine
+  isFavorite: boolean
+  onToggleFavorite: () => void | Promise<void>
+  onBack: () => void | Promise<void>
+  successRate: number | null
+  latestAttempt?: InternationalAttemptSummary
+}
+
+const InternationalPOSOverview: React.FC<InternationalPOSOverviewProps> = ({
+  pos,
+  isFavorite,
+  onToggleFavorite,
+  onBack,
+  successRate,
+  latestAttempt,
+}) => {
+  const { t } = useTranslation()
+  const { setPreference } = useLocaleStore()
+
+  const quickFacts = useMemo(() => [
+    {
+      icon: CreditCard,
+      label: t('internationalPos.quickFacts.cards'),
+      value: pos.basic_info?.supports_foreign_cards
+        ? t('common.yes')
+        : t('common.no'),
+      helper: t('internationalPos.explanations.cards'),
+    },
+    {
+      icon: Smartphone,
+      label: t('internationalPos.quickFacts.contactless'),
+      value: pos.basic_info?.supports_contactless
+        ? t('common.yes')
+        : t('common.no'),
+      helper: t('internationalPos.explanations.contactless'),
+    },
+    {
+      icon: Shield,
+      label: t('internationalPos.quickFacts.dcc'),
+      value: pos.basic_info?.supports_dcc
+        ? t('internationalPos.quickFacts.dccEnabled')
+        : t('internationalPos.quickFacts.dccDisabled'),
+      helper: t('internationalPos.explanations.dcc'),
+    },
+    {
+      icon: Globe2,
+      label: t('internationalPos.quickFacts.language'),
+      value: t('internationalPos.quickFacts.languageValue'),
+      helper: t('internationalPos.explanations.language'),
+    },
+  ], [pos.basic_info, t])
+
+  const supportedCards = pos.basic_info?.supported_card_networks || []
+  const mobilePayments = useMemo(() => [
+    {
+      label: 'Apple Pay',
+      supported: pos.basic_info?.supports_apple_pay,
+    },
+    {
+      label: 'Google Pay',
+      supported: pos.basic_info?.supports_google_pay,
+    },
+    {
+      label: t('internationalPos.quickFacts.hce'),
+      supported: pos.basic_info?.supports_hce_simulation,
+    },
+  ], [pos.basic_info, t])
+
+  const handleSwitchToChinese = () => {
+    setPreference('zh', 'domestic')
+    toast.success(t('internationalPos.actions.switchSuccess'))
+  }
+
+  const renderAttemptStatus = () => {
+    if (!latestAttempt) return null
+    const statusMap: Record<InternationalAttemptSummary['result'], string> = {
+      success: t('internationalPos.attempts.status.success'),
+      failure: t('internationalPos.attempts.status.failure'),
+      unknown: t('internationalPos.attempts.status.unknown'),
+    }
+
+    return (
+      <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+        <p className="font-semibold text-slate-800">
+          {t('internationalPos.attempts.latest')} — {statusMap[latestAttempt.result]}
+        </p>
+        <div className="mt-2 space-y-1 text-xs text-slate-500">
+          {latestAttempt.card_name && (
+            <p>{t('internationalPos.attempts.card', { card: latestAttempt.card_name })}</p>
+          )}
+          {latestAttempt.payment_method && (
+            <p>{t('internationalPos.attempts.method', { method: latestAttempt.payment_method })}</p>
+          )}
+          {latestAttempt.created_at && (
+            <p>{t('internationalPos.attempts.time', { time: new Date(latestAttempt.created_at).toLocaleString() })}</p>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <AnimatedTopNav title={pos.merchant_name} className="sticky top-0 z-10">
+        <AnimatedButton onClick={onBack} variant="ghost" size="sm" className="p-2">
+          <ArrowLeft className="w-5 h-5" />
+        </AnimatedButton>
+        <div className="flex items-center gap-2">
+          <AnimatedButton
+            onClick={handleSwitchToChinese}
+            variant="ghost"
+            size="sm"
+            className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-600"
+          >
+            {t('internationalPos.actions.switch')}
+          </AnimatedButton>
+          <AnimatedButton
+            onClick={onToggleFavorite}
+            variant="ghost"
+            size="sm"
+            className={`p-2 ${isFavorite ? 'text-rose-500' : 'text-slate-500'}`}
+            title={isFavorite ? t('internationalPos.actions.removeFavorite') : t('internationalPos.actions.addFavorite')}
+          >
+            <Heart className={`w-5 h-5 ${isFavorite ? 'fill-current' : ''}`} />
+          </AnimatedButton>
+        </div>
+      </AnimatedTopNav>
+
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-6">
+        <AnimatedCard className="bg-white shadow-sm" variant="elevated" hoverable>
+          <CardContent className="space-y-4 p-6">
+            <div className="flex flex-col gap-2">
+              <p className="text-sm font-medium uppercase tracking-wide text-blue-500">
+                {t('internationalPos.header.badge')}
+              </p>
+              <h1 className="text-3xl font-bold text-slate-900">
+                {t('internationalPos.header.title', { merchant: pos.merchant_name })}
+              </h1>
+              <p className="text-sm text-slate-500">
+                {t('internationalPos.header.subtitle')}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
+              <span className="inline-flex items-center gap-2 rounded-full bg-blue-50 px-3 py-1 text-blue-700">
+                <MapPin className="h-4 w-4" />
+                {pos.address || t('internationalPos.header.unknownAddress')}
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-slate-700">
+                <Navigation className="h-4 w-4" />
+                {t('internationalPos.header.coordinates', {
+                  lat: pos.latitude?.toFixed(4) ?? '--',
+                  lng: pos.longitude?.toFixed(4) ?? '--',
+                })}
+              </span>
+              {typeof successRate === 'number' && (
+                <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-emerald-700">
+                  <Shield className="h-4 w-4" />
+                  {t('internationalPos.header.successRate', { rate: Math.round(successRate * 100) })}
+                </span>
+              )}
+            </div>
+          </CardContent>
+        </AnimatedCard>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {quickFacts.map((fact, index) => (
+            <AnimatedCard key={fact.label} className="bg-white" variant="flat" hoverable>
+              <CardContent className="flex h-full flex-col gap-3 p-5">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="rounded-xl bg-blue-100 p-2 text-blue-600">
+                      <fact.icon className="h-5 w-5" />
+                    </div>
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900">{fact.label}</p>
+                      <p className="text-lg font-bold text-slate-800">{fact.value}</p>
+                    </div>
+                  </div>
+                </div>
+                <p className="flex items-start gap-2 text-xs text-slate-500">
+                  <Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-slate-400" />
+                  <span>{fact.helper}</span>
+                </p>
+              </CardContent>
+            </AnimatedCard>
+          ))}
+        </div>
+
+        <AnimatedCard className="bg-white" variant="flat" hoverable>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle className="text-lg font-semibold text-slate-900">
+              {t('internationalPos.cards.title')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {supportedCards.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {supportedCards.map((network) => (
+                  <span
+                    key={network}
+                    className="inline-flex items-center rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700"
+                  >
+                    {network}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500">{t('internationalPos.cards.unknown')}</p>
+            )}
+
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <p className="text-sm font-semibold text-slate-800">
+                {t('internationalPos.cards.tipTitle')}
+              </p>
+              <p className="mt-1 text-xs text-slate-600">
+                {t('internationalPos.cards.tipDescription')}
+              </p>
+            </div>
+          </CardContent>
+        </AnimatedCard>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <AnimatedCard className="bg-white" variant="flat" hoverable>
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold text-slate-900">
+                {t('internationalPos.mobile.title')}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {mobilePayments.map((item) => (
+                <div key={item.label} className="flex items-center justify-between rounded-lg border border-slate-100 bg-slate-50 px-3 py-2">
+                  <span className="text-sm font-medium text-slate-700">{item.label}</span>
+                  <span className={`text-xs font-semibold ${item.supported ? 'text-emerald-600' : 'text-slate-400'}`}>
+                    {item.supported ? t('common.yes') : t('common.no')}
+                  </span>
+                </div>
+              ))}
+            </CardContent>
+          </AnimatedCard>
+
+          <AnimatedCard className="bg-white" variant="flat" hoverable>
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold text-slate-900 flex items-center gap-2">
+                <Sparkles className="h-5 w-5 text-purple-500" />
+                {t('internationalPos.tips.title')}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-slate-600">
+              {t('internationalPos.tips.items', { returnObjects: true }).map((tip: string, index: number) => (
+                <div key={index} className="flex items-start gap-2">
+                  <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-purple-400" />
+                  <span>{tip}</span>
+                </div>
+              ))}
+            </CardContent>
+          </AnimatedCard>
+        </div>
+
+        <AnimatedCard className="bg-white" variant="flat" hoverable>
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-slate-900">
+              {t('internationalPos.explanations.title')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm text-slate-600">
+            {t('internationalPos.explanations.items', { returnObjects: true }).map((item: string, index: number) => (
+              <div key={index} className="flex items-start gap-2">
+                <Info className="mt-1 h-4 w-4 flex-shrink-0 text-slate-400" />
+                <span>{item}</span>
+              </div>
+            ))}
+          </CardContent>
+        </AnimatedCard>
+
+        {renderAttemptStatus()}
+      </div>
+    </div>
+  )
+}
+
+export default InternationalPOSOverview

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -6,10 +6,12 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import en from '../locales/en.json';
 import ru from '../locales/ru.json';
 import de from '../locales/de.json';
+import zh from '../locales/zh.json';
 
 // 支持的语言列表
 export const supportedLanguages = {
   en: 'English',
+  zh: '简体中文',
   ru: 'Русский',
   de: 'Deutsch'
 };
@@ -19,17 +21,29 @@ export const defaultLanguage = 'en';
 
 // 获取浏览器语言或从本地存储获取
 const getInitialLanguage = (): string => {
-  const savedLanguage = localStorage.getItem('language');
-  if (savedLanguage && Object.keys(supportedLanguages).includes(savedLanguage)) {
-    return savedLanguage;
+  if (typeof window === 'undefined') {
+    return defaultLanguage;
   }
-  
+
+  try {
+    const savedLanguage = window.localStorage.getItem('language');
+    if (savedLanguage && Object.keys(supportedLanguages).includes(savedLanguage)) {
+      return savedLanguage;
+    }
+  } catch (error) {
+    console.warn('Unable to access localStorage for language detection:', error);
+  }
+
   // 检查浏览器语言
-  const browserLanguage = navigator.language.split('-')[0];
-  if (Object.keys(supportedLanguages).includes(browserLanguage)) {
-    return browserLanguage;
+  try {
+    const browserLanguage = window.navigator.language.split('-')[0];
+    if (Object.keys(supportedLanguages).includes(browserLanguage)) {
+      return browserLanguage;
+    }
+  } catch (error) {
+    console.warn('Unable to read browser language for detection:', error);
   }
-  
+
   return defaultLanguage;
 };
 
@@ -40,6 +54,7 @@ i18n
   .init({
     resources: {
       en: { translation: en },
+      zh: { translation: zh },
       ru: { translation: ru },
       de: { translation: de }
     },
@@ -61,7 +76,13 @@ i18n
 export const changeLanguage = (language: string) => {
   if (Object.keys(supportedLanguages).includes(language)) {
     i18n.changeLanguage(language);
-    localStorage.setItem('language', language);
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem('language', language);
+      } catch (error) {
+        console.warn('Unable to persist language preference:', error);
+      }
+    }
   }
 };
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -74,6 +74,8 @@
     "print": "Print",
     "bookmark": "Bookmark",
     "unbookmark": "Remove Bookmark",
+    "yes": "Yes",
+    "no": "No",
     "favorite": "Favorite",
     "unfavorite": "Remove Favorite",
     "like": "Like",
@@ -1467,5 +1469,218 @@
     "loading": "Analyzing your preferences...",
     "error": "Unable to load personalized content",
     "retry": "Retry"
+  },
+  "experiencePrompt": {
+    "badge": "Tailored Experience",
+    "title": "Welcome to Payments Maps",
+    "subtitle": "Choose the language and guidance that fits how you pay in China.",
+    "options": {
+      "domestic": {
+        "title": "中文 · 中国版",
+        "description": "完整的参数、支付网络与技术细节，适合在地用户深入探索。",
+        "hint": "推荐给熟悉中国支付生态的用户",
+        "cta": "进入中国体验",
+        "short": "CN"
+      },
+      "international": {
+        "title": "English · International",
+        "description": "Quick tips, plain-language explanations, and the essentials for paying in China.",
+        "hint": "For travellers, newcomers and expatriates",
+        "cta": "Start international guide",
+        "short": "EN"
+      }
+    },
+    "promo": {
+      "title": "What you will see",
+      "points": [
+        "Interactive maps with verified payment acceptance",
+        "Step-by-step onboarding in your chosen language",
+        "Essential tips for cards, wallets and helpful phrases"
+      ]
+    },
+    "footer": "You can always switch languages later from the menu."
+  },
+  "experience": {
+    "badge": {
+      "domestic": "Chinese Experience",
+      "international": "International Experience"
+    }
+  },
+  "landing": {
+    "hero": {
+      "title": "Payments Maps",
+      "subtitle": "A smart companion for understanding payment options in every corner of China.",
+      "primaryCta": "Get started",
+      "secondaryCta": "Learn more"
+    },
+    "features": {
+      "heading": "Why travellers choose us",
+      "subheading": "Designed with international visitors and local experts working together.",
+      "global": {
+        "title": "City by city",
+        "description": "Discover terminals across major Chinese destinations"
+      },
+      "payments": {
+        "title": "Many ways to pay",
+        "description": "Cards, mobile wallets and alternative channels explained"
+      },
+      "security": {
+        "title": "Trusted data",
+        "description": "Verified contributions with transparent editing trail"
+      },
+      "languages": {
+        "title": "Multi-language",
+        "description": "Friendly copy in Chinese, English, German and Russian"
+      },
+      "community": {
+        "title": "Community powered",
+        "description": "Locals and expats share live updates"
+      },
+      "speed": {
+        "title": "Fast lookup",
+        "description": "Filter and search in seconds, even on the go"
+      }
+    },
+    "stats": {
+      "pos": "POS terminals tracked",
+      "cities": "Cities covered",
+      "users": "Active community members",
+      "availability": "Uptime"
+    },
+    "cta": {
+      "title": "Ready to explore payments in China?",
+      "subtitle": "Join the community and plan every purchase with confidence.",
+      "button": "Create your route"
+    }
+  },
+  "login": {
+    "title": "Welcome to Payments Maps",
+    "subtitle": "Sign in to unlock full payment insights and contribute to the map.",
+    "loading": "Signing in...",
+    "providers": {
+      "google": "Sign in with Google",
+      "github": "Sign in with GitHub",
+      "microsoft": "Sign in with Microsoft",
+      "linuxdo": "Sign in with LinuxDO"
+    },
+    "divider": "or",
+    "guestButton": "Continue as guest (view only)",
+    "notice": {
+      "providers": "Use Google, GitHub, Microsoft or LinuxDO to contribute information.",
+      "terms": "By signing in you agree to the Terms of Service and Privacy Policy.",
+      "guestLimitations": "Guest mode is read-only. To add or edit information please sign in."
+    },
+    "errors": {
+      "google": "Google sign-in failed, please try again.",
+      "github": "GitHub sign-in failed, please try again.",
+      "microsoft": "Microsoft sign-in failed, please try again.",
+      "linuxdo": "LinuxDO sign-in failed, please try again."
+    }
+  },
+  "onboardingTour": {
+    "labels": {
+      "previous": "Back",
+      "next": "Next",
+      "skip": "Skip",
+      "done": "Finish"
+    },
+    "steps": {
+      "map": {
+        "title": "Explore the map",
+        "title_international": "Explore the map",
+        "action": "Tap to view nearby payment-friendly merchants",
+        "action_international": "Tap to see places that work well with foreign cards"
+      },
+      "search": {
+        "title": "Search anything",
+        "title_international": "Search in English or Chinese",
+        "action": "Find merchants, addresses or brands instantly",
+        "action_international": "Type an address or brand, we match both English and Chinese names"
+      },
+      "add": {
+        "title": "Share a POS",
+        "title_international": "Share what you discover",
+        "action": "Report new payment terminals or update details",
+        "action_international": "Tell the community when you find a helpful terminal"
+      },
+      "filter": {
+        "title": "Use filters",
+        "title_international": "Filter by cards & wallets",
+        "action": "Narrow down by network, contactless support and more",
+        "action_international": "Choose the cards or wallets you carry to highlight compatible places"
+      },
+      "profile": {
+        "title": "Your profile",
+        "title_international": "Your dashboard",
+        "action": "Track favourites, history and submissions",
+        "action_international": "Keep bookmarks and edits synced across devices"
+      }
+    }
+  },
+  "internationalPos": {
+    "header": {
+      "badge": "International brief",
+      "title": "{{merchant}} payment overview",
+      "subtitle": "Understand how to pay here in a few seconds.",
+      "unknownAddress": "Address coming soon",
+      "coordinates": "Lat {{lat}}, Lng {{lng}}",
+      "successRate": "{{rate}}% recent success rate"
+    },
+    "quickFacts": {
+      "cards": "Foreign cards accepted",
+      "contactless": "Tap to pay",
+      "dcc": "Currency conversion",
+      "dccEnabled": "Dynamic currency conversion offered",
+      "dccDisabled": "Local currency only",
+      "language": "Staff language",
+      "languageValue": "Basic English assistance",
+      "hce": "Android tap-to-pay"
+    },
+    "explanations": {
+      "title": "What the badges mean",
+      "cards": "Most Visa, Mastercard and UnionPay (foreign-issued) cards are accepted when this shows 'Yes'.",
+      "contactless": "Tap your card or phone without entering a PIN for small amounts.",
+      "dcc": "DCC lets you pay in your home currency but may have a higher exchange rate.",
+      "language": "Our community noted whether staff can communicate in English or offer signage.",
+      "items": [
+        "Always ask to pay in CNY to avoid hidden conversion fees.",
+        "If contactless fails, insert the chip and try again—terminals often prompt for PIN.",
+        "Keep a backup payment option such as cash or Alipay Tour Pass."
+      ]
+    },
+    "cards": {
+      "title": "Supported card networks",
+      "unknown": "Community is still confirming accepted networks.",
+      "tipTitle": "Traveller tip",
+      "tipDescription": "UnionPay-logo credit cards from your bank often work best. Visa and Mastercard typically require offline PIN."
+    },
+    "mobile": {
+      "title": "Mobile wallets"
+    },
+    "tips": {
+      "title": "Payment checklist",
+      "items": [
+        "Carry the passport associated with your card for high-value purchases.",
+        "Prepare to show the last four digits of your card if staff requests verification.",
+        "Some shops only enable foreign cards on select lanes—ask for the international terminal."
+      ]
+    },
+    "attempts": {
+      "latest": "Latest report",
+      "card": "Card used: {{card}}",
+      "method": "Method: {{method}}",
+      "time": "Reported on {{time}}",
+      "status": {
+        "success": "Worked",
+        "failure": "Declined",
+        "unknown": "Result unconfirmed"
+      }
+    },
+    "actions": {
+      "switch": "中文详细版",
+      "switchSuccess": "Switched to the Chinese detailed view.",
+      "addFavorite": "Save to favourites",
+      "removeFavorite": "Remove favourite"
+    }
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -27,6 +27,8 @@
     "cut": "剪切",
     "undo": "撤销",
     "redo": "重做",
+    "yes": "支持",
+    "no": "不支持",
     "select": "选择",
     "selectAll": "全选",
     "clear": "清除",
@@ -1742,6 +1744,219 @@
       "loading": "正在分析您的偏好...",
       "error": "无法加载个性化内容",
       "retry": "重试"
+    }
+  },
+  "experiencePrompt": {
+    "badge": "请选择体验",
+    "title": "欢迎来到 Payments Maps",
+    "subtitle": "我们会根据您的语言与需求定制支付信息。",
+    "options": {
+      "domestic": {
+        "title": "中文 · 中国版",
+        "description": "完整展示终端参数、收单机构、费率与进阶技巧，适合本地深度玩家。",
+        "hint": "熟悉中国支付体系的用户推荐选择",
+        "cta": "进入中国体验",
+        "short": "CN"
+      },
+      "international": {
+        "title": "English · International",
+        "description": "以简洁图文解释POS可用性、国际卡兼容性与旅行提醒，帮助来华用户快速上手。",
+        "hint": "适合游客、外籍人士与留学生",
+        "cta": "启用国际向导",
+        "short": "EN"
+      }
+    },
+    "promo": {
+      "title": "您将体验到",
+      "points": [
+        "实时更新的支付地图，标注社区验证的终端",
+        "符合语言习惯的分步引导与操作提示",
+        "银行卡、移动支付与常见问题的易懂说明"
+      ]
+    },
+    "footer": "您可随时在菜单中重新选择语言与模式。"
+  },
+  "experience": {
+    "badge": {
+      "domestic": "中国版",
+      "international": "国际版"
+    }
+  },
+  "landing": {
+    "hero": {
+      "title": "Payments Maps",
+      "subtitle": "为全球用户提供中国支付环境的实时情报。",
+      "primaryCta": "立即开始",
+      "secondaryCta": "了解详情"
+    },
+    "features": {
+      "heading": "为什么选择我们",
+      "subheading": "由本地玩家与国际用户共同打磨的支付情报平台。",
+      "global": {
+        "title": "覆盖全国",
+        "description": "追踪热门城市与旅行线路的支付终端"
+      },
+      "payments": {
+        "title": "多元支付",
+        "description": "银行卡、移动钱包、备用通道一站式呈现"
+      },
+      "security": {
+        "title": "真实可信",
+        "description": "社区审核与版本记录保障数据可靠"
+      },
+      "languages": {
+        "title": "多语言体验",
+        "description": "中文、英文、德语、俄语界面自由切换"
+      },
+      "community": {
+        "title": "社区驱动",
+        "description": "来自本地居民与外国用户的实时反馈"
+      },
+      "speed": {
+        "title": "快速检索",
+        "description": "随时过滤所需卡组织与功能"
+      }
+    },
+    "stats": {
+      "pos": "收录POS终端",
+      "cities": "覆盖城市",
+      "users": "活跃贡献者",
+      "availability": "平台可用率"
+    },
+    "cta": {
+      "title": "准备好探索中国的支付了吗？",
+      "subtitle": "加入社区，在出发前掌握每一次支付选择。",
+      "button": "规划我的支付地图"
+    }
+  },
+  "login": {
+    "title": "欢迎使用 Payments Maps",
+    "subtitle": "登录后可查看完整支付详情并参与共建。",
+    "loading": "登录中...",
+    "providers": {
+      "google": "使用 Google 登录",
+      "github": "使用 GitHub 登录",
+      "microsoft": "使用 Microsoft 登录",
+      "linuxdo": "使用 LinuxDO 登录"
+    },
+    "divider": "或",
+    "guestButton": "以游客身份继续（仅浏览）",
+    "notice": {
+      "providers": "使用 Google、GitHub、Microsoft 或 LinuxDO 账号即可贡献信息。",
+      "terms": "登录即表示您同意服务条款与隐私政策。",
+      "guestLimitations": "游客模式为只读，若需新增或编辑信息请登录。"
+    },
+    "errors": {
+      "google": "Google 登录失败，请重试。",
+      "github": "GitHub 登录失败，请重试。",
+      "microsoft": "Microsoft 登录失败，请重试。",
+      "linuxdo": "LinuxDO 登录失败，请重试。"
+    }
+  },
+  "onboardingTour": {
+    "labels": {
+      "previous": "上一步",
+      "next": "下一步",
+      "skip": "跳过",
+      "done": "完成"
+    },
+    "steps": {
+      "map": {
+        "title": "浏览地图",
+        "title_international": "Explore the map",
+        "action": "点击查看附近的POS终端与支付能力",
+        "action_international": "Tap to see places friendly to foreign cards"
+      },
+      "search": {
+        "title": "搜索功能",
+        "title_international": "Search in EN / 中文",
+        "action": "根据商户、品牌或地址快速定位",
+        "action_international": "Find merchants by English or Chinese keywords"
+      },
+      "add": {
+        "title": "新增终端",
+        "title_international": "Share a new spot",
+        "action": "上传新POS或补充细节，帮助其他用户",
+        "action_international": "Report useful terminals you discover"
+      },
+      "filter": {
+        "title": "条件筛选",
+        "title_international": "Filter by what you carry",
+        "action": "按卡组织、免密支持等条件过滤",
+        "action_international": "Choose the cards or wallets you use"
+      },
+      "profile": {
+        "title": "个人中心",
+        "title_international": "Your dashboard",
+        "action": "管理收藏、历史记录与贡献",
+        "action_international": "Keep your bookmarks and edits in sync"
+      }
+    }
+  },
+  "internationalPos": {
+    "header": {
+      "badge": "国际用户速览",
+      "title": "{{merchant}} 的支付速读",
+      "subtitle": "几秒钟了解这里如何付款。",
+      "unknownAddress": "地址待补充",
+      "coordinates": "纬度 {{lat}}，经度 {{lng}}",
+      "successRate": "近期开通率 {{rate}}%"
+    },
+    "quickFacts": {
+      "cards": "支持境外卡",
+      "contactless": "是否可闪付",
+      "dcc": "外币结算",
+      "dccEnabled": "支持动态货币转换",
+      "dccDisabled": "仅支持人民币",
+      "language": "服务语言",
+      "languageValue": "店员可提供基础英文协助",
+      "hce": "安卓HCE模拟"
+    },
+    "explanations": {
+      "title": "说明",
+      "cards": "显示“支持”时，通常代表境外发行的 Visa、Mastercard 或银联卡可以刷卡。",
+      "contactless": "可直接挥卡或手机支付，小额通常无需输入密码。",
+      "dcc": "动态货币转换可直接按外币结算，但汇率通常不如人民币划算。",
+      "language": "社区成员记录了店员是否能提供英语服务或对应指引。",
+      "items": [
+        "支付时优先选择人民币结算，避免额外换汇费。",
+        "若闪付失败，可改为插卡重试，可能需要输入密码。",
+        "建议随身携带备用支付方式，如现金或支付宝 Tour Pass。"
+      ]
+    },
+    "cards": {
+      "title": "已确认的卡组织",
+      "unknown": "社区仍在确认具体卡组织，请关注更新。",
+      "tipTitle": "旅行小贴士",
+      "tipDescription": "带有银联标识的信用卡成功率最高；Visa、Mastercard 通常需要离线密码。"
+    },
+    "mobile": {
+      "title": "移动支付"
+    },
+    "tips": {
+      "title": "支付检查清单",
+      "items": [
+        "高额消费请备好护照以便核对信息。",
+        "如店员核对末四位卡号请提前准备。",
+        "部分商户有专门的国际POS，请主动告知需要外卡通道。"
+      ]
+    },
+    "attempts": {
+      "latest": "最新报告",
+      "card": "使用卡片：{{card}}",
+      "method": "支付方式：{{method}}",
+      "time": "报告时间：{{time}}",
+      "status": {
+        "success": "支付成功",
+        "failure": "支付失败",
+        "unknown": "结果待确认"
+      }
+    },
+    "actions": {
+      "switch": "切换到中文详情",
+      "switchSuccess": "已切换至中国版详情。",
+      "addFavorite": "加入收藏",
+      "removeFavorite": "取消收藏"
     }
   }
 }

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { Link, useNavigate } from 'react-router-dom'
-import { ArrowRight, MapPin, CreditCard, Globe2, Shield, Sparkles, ChevronDown, Users, BarChart3, Zap } from 'lucide-react'
+import { ArrowRight, MapPin, CreditCard, Globe2, Shield, Sparkles, ChevronDown, Users, Zap } from 'lucide-react'
 import { useAuthStore } from '@/stores/useAuthStore'
+import { useTranslation } from 'react-i18next'
 
 const LandingPage = () => {
   const navigate = useNavigate()
   const { user } = useAuthStore()
+  const { t } = useTranslation()
   const [scrollY, setScrollY] = useState(0)
 
   useEffect(() => {
@@ -25,47 +27,47 @@ const LandingPage = () => {
   const features = [
     {
       icon: MapPin,
-      title: '全球覆盖',
-      description: '涵盖全球主要城市的支付终端信息',
+      title: t('landing.features.global.title'),
+      description: t('landing.features.global.description'),
       color: 'from-blue-500 to-cyan-500'
     },
     {
       icon: CreditCard,
-      title: '多种支付',
-      description: '支持各类银行卡、移动支付方式',
+      title: t('landing.features.payments.title'),
+      description: t('landing.features.payments.description'),
       color: 'from-purple-500 to-pink-500'
     },
     {
       icon: Shield,
-      title: '安全可靠',
-      description: '企业级安全保障，数据加密传输',
+      title: t('landing.features.security.title'),
+      description: t('landing.features.security.description'),
       color: 'from-green-500 to-emerald-500'
     },
     {
       icon: Globe2,
-      title: '多语言支持',
-      description: '支持中英俄德四种语言界面',
+      title: t('landing.features.languages.title'),
+      description: t('landing.features.languages.description'),
       color: 'from-orange-500 to-red-500'
     },
     {
       icon: Users,
-      title: '社区驱动',
-      description: '用户共同维护，信息实时更新',
+      title: t('landing.features.community.title'),
+      description: t('landing.features.community.description'),
       color: 'from-indigo-500 to-purple-500'
     },
     {
       icon: Zap,
-      title: '极速体验',
-      description: '毫秒级响应，流畅的交互体验',
+      title: t('landing.features.speed.title'),
+      description: t('landing.features.speed.description'),
       color: 'from-yellow-500 to-orange-500'
     }
   ]
 
   const stats = [
-    { value: '10K+', label: 'POS终端' },
-    { value: '50+', label: '覆盖城市' },
-    { value: '1K+', label: '活跃用户' },
-    { value: '99.9%', label: '可用性' }
+    { value: '10K+', label: t('landing.stats.pos') },
+    { value: '50+', label: t('landing.stats.cities') },
+    { value: '1K+', label: t('landing.stats.users') },
+    { value: '99.9%', label: t('landing.stats.availability') }
   ]
 
   return (
@@ -96,11 +98,11 @@ const LandingPage = () => {
             </motion.div>
             
             <h1 className="text-6xl md:text-7xl font-bold mb-6 bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
-              Payments Maps
+              {t('landing.hero.title')}
             </h1>
-            
+
             <p className="text-xl md:text-2xl text-gray-600 mb-8 max-w-2xl mx-auto">
-              全球支付终端信息平台，让支付触手可及
+              {t('landing.hero.subtitle')}
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -110,18 +112,18 @@ const LandingPage = () => {
                   whileTap={{ scale: 0.95 }}
                   className="px-8 py-4 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-full font-semibold text-lg shadow-lg hover:shadow-xl transition-all duration-300 flex items-center gap-2 mx-auto sm:mx-0"
                 >
-                  开始使用
+                  {t('landing.hero.primaryCta')}
                   <ArrowRight className="w-5 h-5" />
                 </motion.button>
               </Link>
-              
+
               <motion.button
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
                 onClick={() => document.getElementById('features')?.scrollIntoView({ behavior: 'smooth' })}
                 className="px-8 py-4 bg-white text-gray-700 rounded-full font-semibold text-lg shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-200"
               >
-                了解更多
+                {t('landing.hero.secondaryCta')}
               </motion.button>
             </div>
           </motion.div>
@@ -148,10 +150,10 @@ const LandingPage = () => {
             className="text-center mb-16"
           >
             <h2 className="text-4xl md:text-5xl font-bold mb-4 text-gray-900">
-              核心功能
+              {t('landing.features.heading')}
             </h2>
             <p className="text-xl text-gray-600">
-              专为全球支付场景设计的智能平台
+              {t('landing.features.subheading')}
             </p>
           </motion.div>
 
@@ -221,10 +223,10 @@ const LandingPage = () => {
           >
             <Sparkles className="w-12 h-12 text-yellow-500 mx-auto mb-6" />
             <h2 className="text-4xl md:text-5xl font-bold mb-6 text-gray-900">
-              准备好了吗？
+              {t('landing.cta.title')}
             </h2>
             <p className="text-xl text-gray-600 mb-8">
-              加入我们，探索全球支付网络
+              {t('landing.cta.subtitle')}
             </p>
             <Link to="/login">
               <motion.button
@@ -232,7 +234,7 @@ const LandingPage = () => {
                 whileTap={{ scale: 0.95 }}
                 className="px-10 py-5 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-full font-semibold text-xl shadow-xl hover:shadow-2xl transition-all duration-300 flex items-center gap-3 mx-auto"
               >
-                立即开始
+                {t('landing.cta.button')}
                 <ArrowRight className="w-6 h-6" />
               </motion.button>
             </Link>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,12 +5,14 @@ import { useAuthStore } from '@/stores/useAuthStore'
 import { signInWithGoogleSupabase, signInWithGitHubSupabase, signInWithMicrosoftSupabase } from '@/lib/supabase-auth'
 import Button from '@/components/ui/Button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card'
+import { useTranslation } from 'react-i18next'
 // 移除Chrome图标导入，使用Google官方SVG图标
 
 const Login = () => {
   const navigate = useNavigate()
   const { user, loading, loginWithLinuxDO } = useAuthStore()
   const [isLoading, setIsLoading] = useState(false)
+  const { t } = useTranslation()
 
   // 如果用户已登录，重定向到首页
   if (user) {
@@ -24,7 +26,7 @@ const Login = () => {
       // OAuth会重定向，不需要手动处理成功状态
     } catch (error) {
       console.error('Google登录失败:', error)
-      toast.error('Google登录失败，请重试')
+      toast.error(t('login.errors.google'))
       setIsLoading(false)
     }
   }
@@ -36,7 +38,7 @@ const Login = () => {
       // OAuth会重定向，不需要手动处理成功状态
     } catch (error) {
       console.error('GitHub登录失败:', error)
-      toast.error('GitHub登录失败，请重试')
+      toast.error(t('login.errors.github'))
       setIsLoading(false)
     }
   }
@@ -48,7 +50,7 @@ const Login = () => {
       // OAuth会重定向，不需要手动处理成功状态
     } catch (error) {
       console.error('Microsoft登录失败:', error)
-      toast.error('Microsoft登录失败，请重试')
+      toast.error(t('login.errors.microsoft'))
       setIsLoading(false)
     }
   }
@@ -60,7 +62,7 @@ const Login = () => {
       // OAuth会重定向，不需要手动处理成功状态
     } catch (error) {
       console.error('LinuxDO登录失败:', error)
-      toast.error('LinuxDO登录失败，请重试')
+      toast.error(t('login.errors.linuxdo'))
       setIsLoading(false)
     }
   }
@@ -75,10 +77,10 @@ const Login = () => {
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl font-bold text-gray-900">
-            欢迎使用 Payments Maps
+            {t('login.title')}
           </CardTitle>
           <CardDescription>
-            发现身边的POS机，分享支付体验
+            {t('login.subtitle')}
           </CardDescription>
         </CardHeader>
         
@@ -96,7 +98,7 @@ const Login = () => {
                 <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
                 <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
               </svg>
-              <span>{loading || isLoading ? '登录中...' : '使用 Google 登录'}</span>
+              <span>{loading || isLoading ? t('login.loading') : t('login.providers.google')}</span>
             </Button>
 
             <Button
@@ -107,7 +109,7 @@ const Login = () => {
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
               </svg>
-              <span>{loading || isLoading ? '登录中...' : '使用 GitHub 登录'}</span>
+              <span>{loading || isLoading ? t('login.loading') : t('login.providers.github')}</span>
             </Button>
 
             <Button
@@ -118,7 +120,7 @@ const Login = () => {
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M11.4 24H0V12.6h11.4V24zM24 24H12.6V12.6H24V24zM11.4 11.4H0V0h11.4v11.4zM24 11.4H12.6V0H24v11.4z"/>
               </svg>
-              <span>{loading || isLoading ? '登录中...' : '使用 Microsoft 登录'}</span>
+              <span>{loading || isLoading ? t('login.loading') : t('login.providers.microsoft')}</span>
             </Button>
 
             <Button
@@ -129,7 +131,7 @@ const Login = () => {
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
               </svg>
-              <span>{loading || isLoading ? '登录中...' : '使用 LinuxDO 登录'}</span>
+              <span>{loading || isLoading ? t('login.loading') : t('login.providers.linuxdo')}</span>
             </Button>
           </div>
 
@@ -138,7 +140,7 @@ const Login = () => {
               <div className="w-full border-t border-gray-200"></div>
             </div>
             <div className="relative flex justify-center">
-              <span className="bg-white px-2 text-xs text-gray-400">或</span>
+              <span className="bg-white px-2 text-xs text-gray-400">{t('login.divider')}</span>
             </div>
           </div>
 
@@ -150,18 +152,18 @@ const Login = () => {
             <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm-.25 5.5a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zM11 11h2v6h-2v-6z"/>
             </svg>
-            <span>以游客身份继续（仅浏览）</span>
+            <span>{t('login.guestButton')}</span>
           </Button>
           
           <div className="text-center">
             <p className="text-xs text-gray-500">
-              请使用 Google、GitHub、Microsoft 或 LinuxDO 账户登录以继续使用服务
+              {t('login.notice.providers')}
             </p>
             <p className="text-xs text-gray-400 mt-1">
-              登录即表示您同意我们的服务条款和隐私政策
+              {t('login.notice.terms')}
             </p>
             <p className="text-xs text-gray-400 mt-1">
-              游客模式仅支持浏览现有信息，无法新增或编辑信息
+              {t('login.notice.guestLimitations')}
             </p>
           </div>
         </CardContent>

--- a/src/pages/POSDetail.tsx
+++ b/src/pages/POSDetail.tsx
@@ -24,6 +24,8 @@ import { FeesConfiguration, feeUtils } from '@/types/fees'
 import { checkAndUpdatePOSStatus, updatePOSStatus, calculatePOSSuccessRate, POSStatus, refreshMapData } from '@/utils/posStatusUtils'
 import { AnimatedTopNav } from '@/components/AnimatedNavigation'
 import { exportToJSON, exportToHTML, exportToPDF, getStyleDisplayName, getFormatDisplayName, type CardStyle, type ExportFormat } from '@/utils/exportUtils'
+import { useLocaleStore } from '@/stores/useLocaleStore'
+import InternationalPOSOverview, { type InternationalAttemptSummary } from '@/components/international/InternationalPOSOverview'
 
 interface Review {
   id: string
@@ -61,6 +63,7 @@ const POSDetail = () => {
   const { user } = useAuthStore()
   const { posMachines, deletePOSMachine } = useMapStore()
   const permissions = usePermissions()
+  const { experience } = useLocaleStore()
   
   const [pos, setPOS] = useState<POSMachine | null>(null)
   const [reviews, setReviews] = useState<Review[]>([])
@@ -684,6 +687,28 @@ const POSDetail = () => {
           <AnimatedButton onClick={() => navigate(-1)}>返回</AnimatedButton>
         </div>
       </div>
+    )
+  }
+
+  if (experience === 'international') {
+    const latestAttempt: InternationalAttemptSummary | undefined = attempts.length > 0
+      ? {
+          result: attempts[0].result,
+          card_name: attempts[0].card_name,
+          payment_method: attempts[0].payment_method,
+          created_at: attempts[0].created_at,
+        }
+      : undefined
+
+    return (
+      <InternationalPOSOverview
+        pos={pos}
+        isFavorite={isFavorite}
+        onToggleFavorite={toggleFavorite}
+        onBack={() => navigate(-1)}
+        successRate={successRate}
+        latestAttempt={latestAttempt}
+      />
     )
   }
 

--- a/src/stores/useLocaleStore.ts
+++ b/src/stores/useLocaleStore.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { changeLanguage, defaultLanguage } from '@/lib/i18n'
+
+export type ExperienceMode = 'domestic' | 'international'
+
+interface LocaleState {
+  language: string
+  experience: ExperienceMode
+  hasSelectedLanguage: boolean
+  hasCompletedTour: boolean
+  setPreference: (language: string, experience: ExperienceMode) => void
+  markTourCompleted: () => void
+  resetTour: () => void
+  clearPreference: () => void
+}
+
+export const useLocaleStore = create<LocaleState>()(
+  persist(
+    (set) => ({
+      language: defaultLanguage,
+      experience: 'international',
+      hasSelectedLanguage: false,
+      hasCompletedTour: false,
+      setPreference: (language, experience) => {
+        changeLanguage(language)
+        set({
+          language,
+          experience,
+          hasSelectedLanguage: true,
+        })
+      },
+      markTourCompleted: () => set({ hasCompletedTour: true }),
+      resetTour: () => set({ hasCompletedTour: false }),
+      clearPreference: () =>
+        set({
+          language: defaultLanguage,
+          experience: 'international',
+          hasSelectedLanguage: false,
+          hasCompletedTour: false,
+        }),
+    }),
+    {
+      name: 'locale-preference',
+      partialize: (state) => ({
+        language: state.language,
+        experience: state.experience,
+        hasSelectedLanguage: state.hasSelectedLanguage,
+        hasCompletedTour: state.hasCompletedTour,
+      }),
+      onRehydrateStorage: () => (state) => {
+        if (!state) return
+        if (state.hasSelectedLanguage && state.language) {
+          changeLanguage(state.language)
+        }
+      },
+    }
+  )
+)


### PR DESCRIPTION
## Summary
- add a persistent locale store and first-run language selector to clearly split Chinese and international experiences
- refresh landing, login, and navigation flows with localized copy plus a guided onboarding tour tied to the selected language
- deliver a simplified international POS overview while keeping the original detailed Chinese view for domestic users

## Testing
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eb334b683883238112268b3eab4fda